### PR TITLE
Added concurrent variable handling

### DIFF
--- a/src/main/vcp_hal/usbd_cdc_interface.c
+++ b/src/main/vcp_hal/usbd_cdc_interface.c
@@ -56,12 +56,16 @@
 #include "usbd_cdc_interface.h"
 #include "stdbool.h"
 
+#include "build/atomic.h"
+#include "drivers/nvic.h"
+
+
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
-#define APP_RX_DATA_SIZE  2048
-#define APP_TX_DATA_SIZE  2048
+#define APP_RX_DATA_SIZE  8192
+#define APP_TX_DATA_SIZE  8192
 
-#define APP_TX_BLOCK_SIZE 512
+#define APP_TX_BLOCK_SIZE 8192
 
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
@@ -73,12 +77,12 @@ USBD_CDC_LineCodingTypeDef LineCoding =
   0x08    /* nb. of bits 8*/
 };
 
-uint8_t UserRxBuffer[APP_RX_DATA_SIZE];/* Received Data over USB are stored in this buffer */
-uint8_t UserTxBuffer[APP_TX_DATA_SIZE];/* Received Data over UART (CDC interface) are stored in this buffer */
+volatile uint8_t UserRxBuffer[APP_RX_DATA_SIZE];/* Received Data over USB are stored in this buffer */
+volatile uint8_t UserTxBuffer[APP_TX_DATA_SIZE];/* Received Data over UART (CDC interface) are stored in this buffer */
 uint32_t BuffLength;
-uint32_t UserTxBufPtrIn = 0;/* Increment this pointer or roll it back to
+volatile uint32_t UserTxBufPtrIn = 0;/* Increment this pointer or roll it back to
                                start address when data are received over USART */
-uint32_t UserTxBufPtrOut = 0; /* Increment this pointer or roll it back to
+volatile uint32_t UserTxBufPtrOut = 0; /* Increment this pointer or roll it back to
                                  start address when data are sent over USB */
 
 uint32_t rxAvailable = 0;
@@ -137,8 +141,8 @@ static int8_t CDC_Itf_Init(void)
   }
 
   /*##-5- Set Application Buffers ############################################*/
-  USBD_CDC_SetTxBuffer(&USBD_Device, UserTxBuffer, 0);
-  USBD_CDC_SetRxBuffer(&USBD_Device, UserRxBuffer);
+  USBD_CDC_SetTxBuffer(&USBD_Device, (uint8_t *)UserTxBuffer, 0);
+  USBD_CDC_SetRxBuffer(&USBD_Device, (uint8_t *)UserRxBuffer);
 
   ctrlLineStateCb = NULL;
   baudRateCb = NULL;
@@ -373,7 +377,11 @@ uint32_t CDC_Send_FreeBytes(void)
         (APP_Rx_ptr_out > APP_Rx_ptr_in ? APP_Rx_ptr_out - APP_Rx_ptr_in : APP_RX_DATA_SIZE - APP_Rx_ptr_in + APP_Rx_ptr_in)
         but without the impact of the condition check.
     */
-    return ((UserTxBufPtrOut - UserTxBufPtrIn) + (-((int)(UserTxBufPtrOut <= UserTxBufPtrIn)) & APP_TX_DATA_SIZE)) - 1;
+    uint32_t bytesFree;
+    ATOMIC_BLOCK(NVIC_PRIO_MAX) { // XXX NVIC_BUILD_PRIORITY(6,0)?
+        bytesFree = ((UserTxBufPtrOut - UserTxBufPtrIn) + (-((int)(UserTxBufPtrOut <= UserTxBufPtrIn)) & APP_TX_DATA_SIZE)) - 1;
+    }
+    return bytesFree;
 }
 
 /**
@@ -391,7 +399,9 @@ uint32_t CDC_Send_DATA(const uint8_t *ptrBuffer, uint32_t sendLength)
             delay(1);
         }
         UserTxBuffer[UserTxBufPtrIn] = ptrBuffer[i];
-        UserTxBufPtrIn = (UserTxBufPtrIn + 1) % APP_TX_DATA_SIZE;
+        ATOMIC_BLOCK(NVIC_PRIO_MAX) { // XXX NVIC_BUILD_PRIORITY(6,0)?
+            UserTxBufPtrIn = (UserTxBufPtrIn + 1) % APP_TX_DATA_SIZE;
+        }
     }
     return sendLength;
 }


### PR DESCRIPTION
There still seems to be a problem.

When `APP_TX_BLOCK_SIZE` is raised to match APP_TX_DATA_SIZE`, then I still get CRC errors. Error counts increase slightly as sizes are increased.

During the 12MB transfer, I see that errors come in the same pattern; groups at around 1/3, intermittently at 2/3 and couples at the end.

Oh, and a 8192 caused connection to drop.

This is the code I'm currently using for testing.